### PR TITLE
Commit SHA dimension allows concurrent Soak Tests

### DIFF
--- a/.github/docker-performance-tests/alarms-poller/Dockerfile
+++ b/.github/docker-performance-tests/alarms-poller/Dockerfile
@@ -10,5 +10,6 @@ CMD python ./poll-during-performance-tests.py --cpu-load-threshold $CPU_LOAD_THR
                                               --num-of-cpus $NUM_OF_CPUS \
                                               --app-process-command-line-dimension-value "$APP_PROCESS_COMMAND_LINE_DIMENSION_VALUE" \
                                               --total-memory-threshold $TOTAL_MEMORY_THRESHOLD \
-                                              --app-platform $APP_PLATFORM \
-                                              --instrumentation-type $INSTRUMENTATION_TYPE
+                                              --target-sha $TARGET_SHA \
+                                              --github-run-id $GITHUB_RUN_ID \
+                                              --image-suffix $IMAGE_SUFFIX

--- a/.github/docker-performance-tests/docker-compose.yml
+++ b/.github/docker-performance-tests/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - AWS_SECRET_ACCESS_KEY
       - AWS_SESSION_TOKEN
       - AWS_DEFAULT_REGION
+      - TARGET_SHA
+      - GITHUB_RUN_ID
       - HOSTMETRICS_INTERVAL_SECS
       - LOG_GROUP_NAME
       - LOGS_NAMESPACE
@@ -57,12 +59,13 @@ services:
       - AWS_DEFAULT_REGION
       - HOSTMETRICS_INTERVAL_SECS
       - NUM_OF_CPUS
+      - TARGET_SHA
       - LOGS_NAMESPACE
       - APP_PROCESS_COMMAND_LINE_DIMENSION_VALUE
       - CPU_LOAD_THRESHOLD
       - TOTAL_MEMORY_THRESHOLD
-      - APP_PLATFORM
-      - INSTRUMENTATION_TYPE
+      - GITHUB_RUN_ID
+      - IMAGE_SUFFIX
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:

--- a/.github/docker-performance-tests/otel-collector/collector-config.yml
+++ b/.github/docker-performance-tests/otel-collector/collector-config.yml
@@ -26,6 +26,18 @@ processors:
         resource_attributes:
           - Key: process.command_line
             Value: ${APP_PROCESS_COMMAND_LINE_DIMENSION_VALUE}
+  metricstransform:
+    transforms:
+      - include: process.*
+        match_type: regexp
+        action: update
+        operations:
+          - action: add_label
+            new_label: commit_sha
+            new_value: ${TARGET_SHA}
+          - action: add_label
+            new_label: github_run_id
+            new_value: ${GITHUB_RUN_ID}
 
 exporters:
   logging:
@@ -39,7 +51,13 @@ exporters:
       enabled: true
     dimension_rollup_option: NoDimensionRollup
     metric_declarations:
-      - dimensions: [[process.command_line]]
+      - dimensions: [
+          [
+            process.command_line,
+            commit_sha,
+            github_run_id
+          ]
+        ]
         metric_name_selectors:
           - process.cpu.time
           # - process.disk.io
@@ -58,5 +76,6 @@ service:
         - hostmetrics
       processors:
         - filter
+        - metricstransform
       exporters:
         - awsemf

--- a/.github/scripts/performance-tests/produce-metric-widget-images.py
+++ b/.github/scripts/performance-tests/produce-metric-widget-images.py
@@ -21,6 +21,8 @@ SOAK_TESTS_SNAPSHOTS_DIR = "soak-tests/snapshots"
 
 # AWS Client API Constants
 
+COMMIT_SHA_DIMENSION_NAME = "commit_sha"
+GITHUB_RUN_ID_DIMENSION_NAME = "github_run_id"
 PROCESS_COMMAND_LINE_DIMENSION_NAME = "process.command_line"
 METRIC_DATA_STATISTIC = "Sum"
 
@@ -131,22 +133,23 @@ def parse_args():
     )
 
     parser.add_argument(
-        "--github-sha",
+        "--target-sha",
         required=True,
         help="""
         The SHA of the commit for the current GitHub workflow run. Used to
-        create a folder for the snapshot PNG files.
+        query Cloudwatch by metric dimension value so metrics returned
+        correspond to the app that was performance tested. Also used to create a
+        folder for the snapshot PNG files.
 
         Examples:
 
-            --github-sha=${{ github.sha }}
+            --target-sha=${{ github.sha }}
         """,
     )
 
     parser.add_argument(
         "--github-run-id",
         required=True,
-        type=int,
         help="""
         The Id for the current GitHub workflow run. Used to create the name of
         the snapshot PNG file.
@@ -219,6 +222,10 @@ if __name__ == "__main__":
                         "process.cpu.time",
                         PROCESS_COMMAND_LINE_DIMENSION_NAME,
                         args.app_process_command_line_dimension_value,
+                        COMMIT_SHA_DIMENSION_NAME,
+                        args.target_sha,
+                        GITHUB_RUN_ID_DIMENSION_NAME,
+                        args.github_run_id,
                         {
                             "id": "cpu_time_raw",
                             "label": "CPU Time Raw",
@@ -264,6 +271,10 @@ if __name__ == "__main__":
                         "process.memory.virtual_usage",
                         PROCESS_COMMAND_LINE_DIMENSION_NAME,
                         args.app_process_command_line_dimension_value,
+                        COMMIT_SHA_DIMENSION_NAME,
+                        args.target_sha,
+                        GITHUB_RUN_ID_DIMENSION_NAME,
+                        args.github_run_id,
                         {
                             "id": "virtual_memory_raw",
                             "label": "Virtual Memory",
@@ -273,6 +284,10 @@ if __name__ == "__main__":
                     [
                         ".",
                         "process.memory.physical_usage",
+                        ".",
+                        ".",
+                        ".",
+                        ".",
                         ".",
                         ".",
                         {
@@ -313,7 +328,7 @@ if __name__ == "__main__":
         ),
     ]
 
-    Path(f"{SOAK_TESTS_SNAPSHOTS_DIR}/{ args.github_sha }").mkdir(
+    Path(f"{SOAK_TESTS_SNAPSHOTS_DIR}/{ args.target_sha }").mkdir(
         parents=True, exist_ok=True
     )
 
@@ -325,7 +340,7 @@ if __name__ == "__main__":
         )["MetricWidgetImage"]
 
         with open(
-            f"{SOAK_TESTS_SNAPSHOTS_DIR}/{args.github_sha}/{args.app_platform}-{args.instrumentation_type}-{snapshot_type}-soak-{args.github_run_id}.png",
+            f"{SOAK_TESTS_SNAPSHOTS_DIR}/{args.target_sha}/{args.app_platform}-{args.instrumentation_type}-{snapshot_type}-soak-{args.github_run_id}.png",
             "wb",
         ) as file_context:
             file_context.write(metric_widget_image_bytes)

--- a/.github/scripts/performance-tests/produce-performance-test-results.py
+++ b/.github/scripts/performance-tests/produce-performance-test-results.py
@@ -16,6 +16,8 @@ logger = logging.getLogger(__file__)
 
 # AWS Client API Constants
 
+COMMIT_SHA_DIMENSION_NAME = "commit_sha"
+GITHUB_RUN_ID_DIMENSION_NAME = "github_run_id"
 PROCESS_COMMAND_LINE_DIMENSION_NAME = "process.command_line"
 METRIC_DATA_STATISTIC = "Sum"
 
@@ -112,6 +114,34 @@ def parse_args():
     )
 
     parser.add_argument(
+        "--target-sha",
+        required=True,
+        help="""
+        The SHA of the commit for the current GitHub workflow run. Used to
+        query Cloudwatch by metric dimension value so metrics returned
+        correspond to the app that was performance tested.
+
+        Examples:
+
+            --target-sha=${{ github.sha }}
+        """,
+    )
+
+    parser.add_argument(
+        "--github-run-id",
+        required=True,
+        help="""
+        The Id for the current GitHub workflow run. Used to query Cloudwatch by
+        metric dimension value so metrics returned correspond to the app that
+        was performance tested.
+
+        Examples:
+
+            --github-run-id=$GITHUB_RUN_ID
+        """,
+    )
+
+    parser.add_argument(
         "--test-duration-minutes",
         required=True,
         type=int,
@@ -148,6 +178,14 @@ if __name__ == "__main__":
                         {
                             "Name": PROCESS_COMMAND_LINE_DIMENSION_NAME,
                             "Value": args.app_process_command_line_dimension_value,
+                        },
+                        {
+                            "Name": COMMIT_SHA_DIMENSION_NAME,
+                            "Value": args.target_sha,
+                        },
+                        {
+                            "Name": GITHUB_RUN_ID_DIMENSION_NAME,
+                            "Value": args.github_run_id,
                         }
                     ],
                 },
@@ -177,6 +215,14 @@ if __name__ == "__main__":
                         {
                             "Name": PROCESS_COMMAND_LINE_DIMENSION_NAME,
                             "Value": args.app_process_command_line_dimension_value,
+                        },
+                        {
+                            "Name": COMMIT_SHA_DIMENSION_NAME,
+                            "Value": args.target_sha,
+                        },
+                        {
+                            "Name": GITHUB_RUN_ID_DIMENSION_NAME,
+                            "Value": args.github_run_id,
                         }
                     ],
                 },
@@ -196,6 +242,14 @@ if __name__ == "__main__":
                         {
                             "Name": PROCESS_COMMAND_LINE_DIMENSION_NAME,
                             "Value": args.app_process_command_line_dimension_value,
+                        },
+                        {
+                            "Name": COMMIT_SHA_DIMENSION_NAME,
+                            "Value": args.target_sha,
+                        },
+                        {
+                            "Name": GITHUB_RUN_ID_DIMENSION_NAME,
+                            "Value": args.github_run_id,
                         }
                     ],
                 },

--- a/.github/workflows/soak-testing.yml
+++ b/.github/workflows/soak-testing.yml
@@ -5,13 +5,22 @@
 
 name: Soak Testing
 on:
+  workflow_dispatch:
+    inputs:
+      target_commit_sha:
+        description: 'The commit SHA on this repo to use for the Soak Tests.'
+        required: true
+      test_duration_minutes:
+        description: 'The duration of the Soak Tests in minutes.'
+        required: true
+        default: 300
   schedule:
     - cron: '0 */24 * * *'
 env:
   # NOTE: The configuration of `APP_PROCESS_EXECUTABLE_NAME` is repo dependent
   APP_PROCESS_EXECUTABLE_NAME: python3
   AWS_DEFAULT_REGION: us-east-1
-  TEST_DURATION_MINUTES: 300
+  DEFAULT_TEST_DURATION_MINUTES: 300
   HOSTMETRICS_INTERVAL_SECS: 600
   CPU_LOAD_THRESHOLD: 71
   TOTAL_MEMORY_THRESHOLD: 1610612736
@@ -38,14 +47,21 @@ jobs:
     env:
       # NOTE: The configuration of `APP_PATH` is repo dependent
       APP_PATH: integration-test-apps/${{ matrix.instrumentation-type}}-instrumentation/${{ matrix.app-platform }}
-      IMAGE_SUFFIX: ${{ matrix.app-platform }}-${{ matrix.instrumentation-type }}-${{ github.sha }}
-      # TODO: Does the LOGS_NAMESPACE need a `-$GITHUB_RUN_ID`? (Only if we run
-      # multiple Soak Tests at a time, which we probably will not do?). If we do
-      # need it, move to steps below to access $GITHUB_RUN_ID.
       LOGS_NAMESPACE: ${{ github.repository }}/soak-tests-${{ matrix.app-platform }}-${{ matrix.instrumentation-type }}
     steps:
+      - name: Configure Performance Test Duration
+        run: |
+          echo "TEST_DURATION_MINUTES=${{ github.event.inputs.test_duration_minutes || env.DEFAULT_TEST_DURATION_MINUTES }}" | tee --append $GITHUB_ENV;
       # NOTE: The configuration of `APP_PROCESS_COMMAND_LINE_DIMENSION_VALUE` is
       # repo dependent
+      - name: Use input as commit SHA
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          echo "TARGET_SHA=${{ github.event.inputs.target_commit_sha }}" | tee --append $GITHUB_ENV;
+      - name: Use latest as commit SHA
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        run: |
+          echo "TARGET_SHA=${{ github.sha }}" | tee --append $GITHUB_ENV;
       - name: Configure Auto Instrumentation-Type Specific Values
         if: ${{ matrix.instrumentation-type == 'auto' }}
         run: |-
@@ -58,14 +74,31 @@ jobs:
           echo 'APP_PROCESS_COMMAND_LINE_DIMENSION_VALUE<<EOF' >> $GITHUB_ENV
           echo '/usr/local/bin/python3 /app/application.py' | tee --append $GITHUB_ENV;
           echo 'EOF' >> $GITHUB_ENV
+      # WARNING: In an edge case, if two jobs use the same commit at the same
+      # time, they will race to push and pull Docker Images!
+      - name: Create Image Suffix
+        run: |
+          echo "IMAGE_SUFFIX=${{ matrix.app-platform }}-${{ matrix.instrumentation-type }}-${{ env.TARGET_SHA }}" | tee --append $GITHUB_ENV;
       - name: Clone This Repo First
         uses: actions/checkout@v2
+        with:
+          ref: ${{ env.TARGET_SHA }}
+      # FIXME: This uses the latest Commit SHA of the upstream Core repo. We
+      # should provide it as an input to consider the edge case where we want to
+      # run against a specific Core repo change. For the manual
+      # instrumentation app.
+      # FIXME: We might also consider making this configurable for the
+      # Auto-Instrumentation app.
       - name: Clone OpenTelemetry Core Repo
         uses: actions/checkout@v2
         if: ${{ matrix.instrumentation-type == 'manual' }}
         with:
           repository: open-telemetry/opentelemetry-python
           path: ${{ env.APP_PATH }}/opentelemetry-python-core
+      # FIXME: This uses the latest Commit SHA of the upstream Contrib repo. We
+      # should provide it as an input to consider the edge case where we want to
+      # run against a specific Contrib repo change. For the manual
+      # instrumentation app.
       - name: Clone OpenTelemetry Contrib Repo
         uses: actions/checkout@v2
         if: ${{ matrix.instrumentation-type == 'manual' }}
@@ -87,7 +120,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ env.TARGET_SHA }}
           restore-keys: |
             ${{ runner.os }}-buildx-
       - name: Extract metadata (tags, labels) for Docker
@@ -131,8 +164,7 @@ jobs:
           INSTANCE_ID: ${{ github.run_id }}-${{ github.run_number }}
           LISTEN_ADDRESS: 0.0.0.0:8080
           LOG_GROUP_NAME: otel-sdk-performance-tests
-          APP_PLATFORM: ${{ matrix.app-platform }}
-          INSTRUMENTATION_TYPE: ${{ matrix.instrumentation-type }}
+          TARGET_SHA: ${{ env.TARGET_SHA }}
           # Also uses:
           # LOGS_NAMESPACE
           # LOG_STREAM_NAME
@@ -144,6 +176,8 @@ jobs:
           # CPU_LOAD_THRESHOLD
           # TOTAL_MEMORY_THRESHOLD
           # AWS_DEFAULT_REGION
+          # IMAGE_SUFFIX
+          # GITHUB_RUN_ID
         run: >-
           docker-compose up --build;
           RUN_EXIT_CODE=$(docker inspect $(docker ps --quiet --all --filter "name=docker-performance-tests_alarms-poller") --format="{{.State.ExitCode}}");
@@ -162,9 +196,9 @@ jobs:
           --num-of-cpus ${{ env.NUM_OF_CPUS }}
           --app-process-command-line-dimension-value "${{ env.APP_PROCESS_COMMAND_LINE_DIMENSION_VALUE }}"
           --total-memory-threshold ${{ env.TOTAL_MEMORY_THRESHOLD }}
-          --test-duration-minutes ${{ env.TEST_DURATION_MINUTES }}
-          --github-sha ${{ github.sha }}
+          --target-sha ${{ env.TARGET_SHA }}
           --github-run-id $GITHUB_RUN_ID
+          --test-duration-minutes ${{ env.TEST_DURATION_MINUTES }}
           --app-platform ${{ matrix.app-platform }}
           --instrumentation-type ${{ matrix.instrumentation-type }}
           --max-benchmarks-to-keep ${{ env.MAX_BENCHMARKS_TO_KEEP }}
@@ -175,7 +209,7 @@ jobs:
           git fetch;
           git checkout gh-pages;
           git add soak-tests/snapshots;
-          git commit -m "Adding Soak Tests Snapshots from ${{ github.sha }}";
+          git commit -m "Adding Soak Tests Snapshots from ${{ env.TARGET_SHA }}";
           git push;
           git checkout main;
       - name: Prepare Performance Test results as JSON output
@@ -187,10 +221,11 @@ jobs:
           --app-process-command-line-dimension-value "${{ env.APP_PROCESS_COMMAND_LINE_DIMENSION_VALUE }}"
           --total-memory-threshold ${{ env.TOTAL_MEMORY_THRESHOLD }}
           --test-duration-minutes ${{ env.TEST_DURATION_MINUTES }}
+          --target-sha ${{ env.TARGET_SHA }}
+          --github-run-id $GITHUB_RUN_ID
       - name: Is this the first time we run Performance Tests for this commit?
-        if: ${{ github.event_name == 'schedule' }}
         continue-on-error: true
-        id: check-performance-tests-already-reported
+        id: check-is-first-time-reporting-commit
         run: |
           git checkout gh-pages;
           HAS_RESULTS_ALREADY=$(
@@ -205,7 +240,6 @@ jobs:
           [[ $HAS_RESULTS_ALREADY == false ]]
       - name: Graph and Report Performance Test Averages result
         uses: NathanielRN/github-action-benchmark@v1.8.3-alpha3
-        if: steps.check-performance-tests-already-reported.outcome == 'failure'
         continue-on-error: true
         id: check-failure-after-performance-tests
         with:
@@ -219,12 +253,15 @@ jobs:
           # https://github.com/open-telemetry/opentelemetry-python/pull/1478
           # comment-always: true
           fail-on-alert: true
-          auto-push: ${{ github.ref == 'refs/heads/main' }}
+          auto-push: ${{ github.event_name == 'schedule' &&
+            steps.check-is-first-time-reporting-commit.outcome == 'success' &&
+            github.ref == 'refs/heads/main' }}
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: soak-tests/per-commit-overall-results
       - name: Publish Issue if failed DURING Performance Tests
         uses: JasonEtco/create-an-issue@v2
-        if: steps.check-failure-during-performance-tests.outcome == 'failure'
+        if: ${{ github.event_name == 'schedule' &&
+          steps.check-failure-during-performance-tests.outcome == 'failure' }}
         env:
           APP_PLATFORM: ${{ matrix.app-platform }}
           INSTRUMENTATION_TYPE: ${{ matrix.instrumentation-type }}
@@ -233,7 +270,8 @@ jobs:
           filename: .github/auto-issue-templates/failure-during-soak_tests.md
       - name: Publish Issue if failed AFTER Performance Tests
         uses: NathanielRN/create-an-issue@v2.5.1-alpha2
-        if: steps.check-failure-after-performance-tests.outcome == 'failure'
+        if: ${{ github.event_name == 'schedule' &&
+          steps.check-failure-after-performance-tests.outcome == 'failure' }}
         env:
           APP_PLATFORM: ${{ matrix.app-platform }}
           INSTRUMENTATION_TYPE: ${{ matrix.instrumentation-type }}
@@ -241,7 +279,8 @@ jobs:
         with:
           filename: .github/auto-issue-templates/failure-after-soak_tests.md
       - name: Check for Performance Degradation either DURING or AFTER Performance Tests
-        if: steps.check-failure-during-performance-tests.outcome == 'failure' || steps.check-failure-after-performance-tests.outcome == 'failure'
+        if: ${{ steps.check-failure-during-performance-tests.outcome == 'failure' ||
+          steps.check-failure-after-performance-tests.outcome == 'failure' }}
         run: >-
           echo 'Performance Tests failed, see the logs above for details';
           exit 1;


### PR DESCRIPTION
We add a `commit_sha` dimension to the metrics generated by the `hostmetrics:` receiver so that we can run multiple Soak Tests at the same time.

Additionally, this allows us to add the `workflow_dispatch:` event. This event will only generate 'snapshots' but will not generate a point on the Graph Visualization "after" the Soak Tests.